### PR TITLE
Add UMA tutorial notebook

### DIFF
--- a/notebooks/uma_workflow_example.ipynb
+++ b/notebooks/uma_workflow_example.ipynb
@@ -1,0 +1,103 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a118f74f",
+   "metadata": {},
+   "source": [
+    "# UMA Integration Example\n",
+    "This notebook shows how to start the UMA server, call it via Python, and run ORCA using the external client."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e13c83c",
+   "metadata": {},
+   "source": [
+    "## Start UMA server\n",
+    "Run `umaserver` in the background. In a real workflow you may want to specify the model with `-m` and the port with `-b`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d2c52a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess, time\n",
+    "server_proc = subprocess.Popen(['umaserver'])\n",
+    "# wait briefly for the server to start\n",
+    "time.sleep(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "999cb94f",
+   "metadata": {},
+   "source": [
+    "## Calculate energy with `submit_uma`\n",
+    "Use the client helper to send a single-point calculation to the server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51f8dd52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from umaexttool.client import submit_uma\n",
+    "atom_types = ['H', 'F']\n",
+    "coords = [(0.0, 0.0, 0.0), (0.0, 0.0, 0.9)]\n",
+    "energy, grad = submit_uma('127.0.0.1:8888', atom_types, coords, charge=0, mult=1, dograd=True, nthreads=1)\n",
+    "print('Energy:', energy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5706716",
+   "metadata": {},
+   "source": [
+    "## Run ORCA with `umaclient.sh`\n",
+    "ORCA can use `umaclient.sh` as the external tool. Here we run a minimal job using `subprocess`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3af2f276",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import textwrap, os, subprocess\n",
+    "orca_input = textwrap.dedent('''\n",
+    "! sp\n",
+    "%method\n",
+    "  progext \"../umaclient.sh\"\n",
+    "end\n",
+    "*xyz 0 1\n",
+    "  H 0 0 0\n",
+    "  F 0 0 0.9\n",
+    "*\n",
+    "''')\n",
+    "with open('umaclient_test.inp', 'w') as f:\n",
+    "    f.write(orca_input)\n",
+    "subprocess.run(['orca', 'umaclient_test.inp'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c5db0f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "server_proc.terminate()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/uma/README.md
+++ b/uma/README.md
@@ -57,3 +57,5 @@ options:
 ## Installation
 If not detected, fairchem will be installed to a `.venv` directory by the wrapper scripts the first time you are using them.
 Depending on your download speed, this might take a while.
+## Notebook example
+See [../notebooks/uma_workflow_example.ipynb](../notebooks/uma_workflow_example.ipynb) for a Jupyter notebook that demonstrates starting the UMA server, submitting jobs with `submit_uma`, and running ORCA via `umaclient.sh`.


### PR DESCRIPTION
## Summary
- add a Jupyter notebook showing how to launch the UMA server, call `submit_uma`, and run ORCA with `umaclient.sh`
- mention the new notebook in the UMA README

## Testing
- `pip install nbformat`

------
https://chatgpt.com/codex/tasks/task_e_6866a92e7500832096835c0f6c1851c9